### PR TITLE
Update minimum compatible Julia version to v1.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 # Documentation: https://github.com/JuliaCI/Appveyor.jl
 environment:
   matrix:
-  - julia_version: 1.0
+  - julia_version: 1.6
   - julia_version: nightly
 platform:
   - x86

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Tom Kwong <tk3369@gmail.com>"]
 version = "1.1.0"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Update support from Julia v1.1 to Julia v1.6, which is the current LTS. This unlocks the door to some niceties, e.g. `isnothing`.

Contributes to #7.