### PR TITLE
Expand shift to handle negative step

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ You can move the head pointer in any direction:
 ```
 forward!(h)              # CircularList.List(0,1,2)
 backward!(h)             # CircularList.List(2,0,1)
-shift!(h, 2, :forward)   # CircularList.List(1,2,0)
-shift!(h, 2, :backward)  # CircularList.List(2,0,1)
+shift!(h, 2)             # CircularList.List(1,2,0)
+shift!(h, -2)            # CircularList.List(2,0,1)
 ```
 
 Or, if you have a reference to a specific node, you can jump to that node directly and that node becomes the head!

--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -92,15 +92,26 @@ end
 
 """
 Shift the current pointer forward or backward.
+The direction (:forward or :backward) can optional be provided to make it explicit.
 """
 function shift!(CL::List, steps::Int, direction::Symbol)
-    for i in 1:steps
-        if direction == :forward
-            CL.current = CL.current.next
-        elseif direction == :backward
+    if direction == :forward
+        return shift!(CL, steps)
+    elseif direction == :backward
+        return shift!(CL, -steps)
+    end
+    error("Wrong direction: $direction")
+end
+
+function shift!(CL::List, steps::Int)
+    if steps < 0
+        steps = -steps
+        for i in 1:steps
             CL.current = CL.current.prev
-        else
-            error("Wrong direction: $direction")
+        end
+    else
+        for i in 1:steps
+            CL.current = CL.current.next
         end
     end
     return CL

--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -2,15 +2,15 @@ module CircularList
 
 import Base: insert!, delete!, length, size, eltype, iterate, show
 
-export circularlist, length, size, current, previous, next, 
+export circularlist, length, size, current, previous, next,
     insert!, delete!, shift!, forward!, backward!, jump!,
     eltype, iterate, show, head, tail
 
 """
 Doubly linked list implementation
 """
-mutable struct Node{T} 
-    data::Union{T, Nothing} 
+mutable struct Node{T}
+    data::Union{T, Nothing}
     prev::Union{Node{T}, Nothing}
     next::Union{Node{T}, Nothing}
 end
@@ -18,7 +18,7 @@ end
 """
 List is used to hold a pre-allocated vector of nodes.
 """
-mutable struct List{T} 
+mutable struct List{T}
     nodes::Vector{Node{T}}      # preallocated array of nodes
     current::Node{T}            # current "head" or the circular list
     length::Int                 # number of active elements
@@ -60,9 +60,9 @@ function allocate!(CL::List, T::DataType)
 end
 
 "Insert a new node after the current node and return the new node."
-function insert!(CL::List, data) 
+function insert!(CL::List, data)
     cl = CL.current
-    
+
     n = allocate!(CL, typeof(data))  # make a new node and arrange prev/next pointers
     n.data = data
     n.prev = cl
@@ -70,7 +70,7 @@ function insert!(CL::List, data)
 
     cl.next = n         # fix prev node's next pointer
     n.next.prev = n     # fix next node's prev pointer
-    
+
     CL.current = n     # move pointer to newly inserted node
     return CL
 end
@@ -95,7 +95,7 @@ Shift the current pointer forward or backward.
 """
 function shift!(CL::List, steps::Int, direction::Symbol)
     for i in 1:steps
-        if direction == :forward 
+        if direction == :forward
             CL.current = CL.current.next
         elseif direction == :backward
             CL.current = CL.current.prev
@@ -161,4 +161,3 @@ function show(io::IO, node::Node{T}) where T
 end
 
 end # module
-

--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -109,10 +109,10 @@ function shift!(CL::List, steps::Int)
 end
 
 "Shift the current pointer forward."
-forward!(CL::List) = shift!(CL, 1, :forward)
+forward!(CL::List) = shift!(CL, 1)
 
 "Shift the current pointer backward."
-backward!(CL::List) = shift!(CL, 1, :backward)
+backward!(CL::List) = shift!(CL, -1)
 
 "Return the current node."
 current(CL::List) = CL.current

--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -94,23 +94,14 @@ end
 Shift the current pointer forward or backward.
 The direction (:forward or :backward) can optional be provided to make it explicit.
 """
-function shift!(CL::List, steps::Int, direction::Symbol)
-    if direction == :forward
-        return shift!(CL, steps)
-    elseif direction == :backward
-        return shift!(CL, -steps)
-    end
-    error("Wrong direction: $direction")
-end
-
 function shift!(CL::List, steps::Int)
     if steps < 0
         steps = -steps
-        for i in 1:steps
+        for _ in 1:steps
             CL.current = CL.current.prev
         end
     else
-        for i in 1:steps
+        for _ in 1:steps
             CL.current = CL.current.next
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,21 @@ using Test
     @test current(CL).prev.data == 0
     @test current(CL).prev.prev.data == 1
 
+    # shift!
+    CL = circularlist(6:10)
+    shift!(CL, 2)
+    @test current(CL).data == 8
+    shift!(CL, 2, :forward)
+    @test current(CL).data == 10
+    shift!(CL, -2, :backward)
+    @test current(CL).data == 7
+    shift!(CL, -2)
+    @test current(CL).data == 10
+    shift!(CL, -2, :forward)
+    @test current(CL).data == 8
+    shift!(CL, 2, :backward)
+    @test current(CL).data == 6
+
     # auto resize feature
     CL = circularlist("str_0", capacity = 5)
     for i in 1:100

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,10 +30,13 @@ using Test
 
     # shift!
     CL = circularlist(6:10)
+    node = current(CL)
     shift!(CL, 2)
     @test current(CL).data == 8
     shift!(CL, -1)
     @test current(CL).data == 7
+    jump!(CL, node)
+    @test current(CL).data == 6
 
     # auto resize feature
     CL = circularlist("str_0", capacity = 5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,16 +32,8 @@ using Test
     CL = circularlist(6:10)
     shift!(CL, 2)
     @test current(CL).data == 8
-    shift!(CL, 2, :forward)
-    @test current(CL).data == 10
-    shift!(CL, -2, :backward)
+    shift!(CL, -1)
     @test current(CL).data == 7
-    shift!(CL, -2)
-    @test current(CL).data == 10
-    shift!(CL, -2, :forward)
-    @test current(CL).data == 8
-    shift!(CL, 2, :backward)
-    @test current(CL).data == 6
 
     # auto resize feature
     CL = circularlist("str_0", capacity = 5)


### PR DESCRIPTION
Changelog:-
- Implemented a method of `shift!(CL::List, step::Int)` that handles negative steps.
- Extended this support to the existing `shift!(CL::List, step::Int, direction::Symbol)` method.
- Wrote tests for `shift!` including the new logic.
- Removed extra whitespaces/newlines (automatic by VS Code).

Contributes to #7.