### PR TITLE
Remove `List.capacity`

### DIFF
--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -23,7 +23,6 @@ mutable struct List{T}
     current::Node{T}            # current "head" or the circular list
     length::Int                 # number of active elements
     last::Int                   # last index of the nodes array
-    capacity::Int               # size of the nodes array
 end
 
 "Create a circular list with the specified data element."
@@ -33,7 +32,7 @@ function circularlist(data::T; capacity = 100) where T
     n.data = data
     n.prev = n
     n.next = n
-    return List(nodes, n, 1, 1, capacity)
+    return List(nodes, n, 1, 1)
 end
 
 "Create a circular list from any vector"
@@ -51,11 +50,9 @@ length(CL::List) = CL.length
 
 "Allocates a new uninitialized node in the circular list"
 function allocate!(CL::List, T::DataType)
-    if CL.last == CL.capacity   # exceeded capacity...auto resize.
-        newcapacity = CL.capacity * 2
-        additional  = newcapacity - CL.capacity
+    if CL.last == length(CL.nodes)   # exceeded capacity...auto resize.
+        additional = length(CL.nodes)
         CL.nodes = vcat(CL.nodes, [Node{T}(nothing, nothing, nothing) for _ in 1:additional])
-        CL.capacity = newcapacity
     end
     CL.length += 1
     CL.last += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test
 @testset "CircularList.jl" begin
 
     # general/peek
-    CL = circularlist(0) 
+    CL = circularlist(0)
     @test length(CL) == 1
     @test current(CL) == previous(CL)
     @test current(CL) == next(CL)
@@ -34,7 +34,7 @@ using Test
         insert!(CL, "str_$i")
     end
     @test length(CL) == 101
-    @test CL.capacity == 160   # 5 * 2 * 2 * 2 * 2 * 2 = 160
+    @test length(CL.nodes) == 160   # 5 * 2 * 2 * 2 * 2 * 2 = 160
 
     # forward -- testing next links
     let curr = current(CL)


### PR DESCRIPTION
Since we should always have `CL.capacity == length(CL.nodes)`.

Also simplified the calculation of additional nodes since it will just be the current nodes length.

Contributes to #7.