### PR TITLE
Test show with the help of string

### DIFF
--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -145,14 +145,12 @@ size(CL::List) = (CL.length, )
 
 "Show list."
 function show(io::IO, CL::List{T}) where T
-    print(io, "CircularList.List([")
-    i = 1
-    for x in CL
-        show(io, x)
-        i += 1
-        i <= length(CL) && print(io, ",")
-    end
-    print(io, "])")
+    print(
+        io,
+        "CircularList.List([",
+        join(collect(CL),","),
+        "])",
+    )
 end
 
 "Show node"

--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -145,14 +145,14 @@ size(CL::List) = (CL.length, )
 
 "Show list."
 function show(io::IO, CL::List{T}) where T
-    print(io, "CircularList.List(")
+    print(io, "CircularList.List([")
     i = 1
     for x in CL
         show(io, x)
         i += 1
         i <= length(CL) && print(io, ",")
     end
-    print(io, ")")
+    print(io, "])")
 end
 
 "Show node"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,6 @@ using Test
     @test size(CL) == (10,)
 
     # test show (by using string)
-    @test string(CL) == "CircularList.List(13,2,3,4,5,6,7,8,11,12)"
+    @test string(CL) == "CircularList.List([13,2,3,4,5,6,7,8,11,12])"
     @test string(current(CL)) == "CircularList.Node(13)"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,11 +82,7 @@ using Test
     @test length(CL) == 10
     @test size(CL) == (10,)
 
-    # dummy tests to pass coverge
-    println("dummy tests")
-    show(CL)
-    println()
-    show(current(CL))
-    println()
-    println()
+    # test show (by using string)
+    @test string(CL) == "CircularList.List(13,2,3,4,5,6,7,8,11,12)"
+    @test string(current(CL)) == "CircularList.Node(13)"
 end


### PR DESCRIPTION
To satisfy code coverage, we will need to run `Base.show`. This can be done using [`Base.string`](https://docs.julialang.org/en/v1/base/strings/#Base.string) which defaults to calling `Base.print` and then `Base.show`.

Since it is recommended for [`Base.show`](https://docs.julialang.org/en/v1/base/io-network/#Base.show-Tuple%7BIO,%20Any%7D) to be parseable Julia code when possible, we may also wish to consider adding the square bracket.

We use [`Base.join`](https://docs.julialang.org/en/v1/base/strings/#Base.join) to help us show the nodes without manually iterating.