### PR TITLE
Implement `move!`

### DIFF
--- a/src/CircularList.jl
+++ b/src/CircularList.jl
@@ -3,7 +3,7 @@ module CircularList
 import Base: insert!, delete!, length, size, eltype, iterate, show
 
 export circularlist, length, size, current, previous, next,
-    insert!, delete!, shift!, forward!, backward!, jump!,
+    insert!, delete!, shift!, move!, forward!, backward!, jump!,
     eltype, iterate, show, head, tail
 
 """
@@ -105,6 +105,30 @@ function shift!(CL::List, steps::Int)
             CL.current = CL.current.next
         end
     end
+    return CL
+end
+
+"""
+Move the current head node in the circular list the given number of steps.
+Move forward if positive, and backward if negative.
+"""
+function move!(CL::List, steps::Int)
+    n = CL.current
+    n.prev.next = n.next   # fix prev node's next pointer
+    n.next.prev = n.prev   # fix next node's prev pointer
+    CL.current = n.prev    # reset List's current pointer to prev
+
+    shift!(CL, steps)
+
+    cl = CL.current
+
+    n.prev = cl
+    n.next = cl.next
+
+    cl.next = n         # fix prev node's next pointer
+    n.next.prev = n     # fix next node's prev pointer
+
+    CL.current = n     # move pointer to newly inserted node
     return CL
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,20 @@ using Test
     jump!(CL, node)
     @test current(CL).data == 6
 
+    # move!
+    CL = circularlist(6:10)
+    move!(CL, 3)
+    n = current(CL)
+    @test n.data == 6
+    @test n.prev.data == 9
+    @test n.next.data == 10
+    shift!(CL, 1)
+    move!(CL, -2)
+    n = current(CL)
+    @test n.data == 10
+    @test n.prev.data == 8
+    @test n.next.data == 9
+
     # auto resize feature
     CL = circularlist("str_0", capacity = 5)
     for i in 1:100


### PR DESCRIPTION
It is helpful to be able to do a remove-shift-insert of the current node. However, if we make use of the current interface as follows:

```julia
node = current(CL)
delete!(CL)
shift!(CL, steps)
insert!(CL, node.data)
```

a new node will be created, and so the reference to the old node will be outdated.

With the new interface of `move!(CL, steps)`, the node is reused and so an external reference to it will remain relevant.