### PR TITLE
Add direction argument to shift! calls in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ You can move the head pointer in any direction:
 ```
 forward!(h)              # CircularList.List(0,1,2)
 backward!(h)             # CircularList.List(2,0,1)
-shift!(h, 2)             # CircularList.List(1,2,0)
-shift!(h, -2)            # CircularList.List(2,0,1)
+shift!(h, 2, :forward)             # CircularList.List(1,2,0)
+shift!(h, 2, :backward)            # CircularList.List(2,0,1)
 ```
 
 Or, if you have a reference to a specific node, you can jump to that node directly and that node becomes the head!


### PR DESCRIPTION
The example code segment in the `README.md` will not run successfully.

```
using CircularList

function main()
    h = circularlist(0)      # CircularList.List(0)
    insert!(h, 1)            # CircularList.List(1,0)
    shift!(h, 2, :forward)             # CircularList.List(1,2,0)
end

main()
```

throws

`LoadError: MethodError: no method matching shift!(::CircularList.List{Int64}, ::Int64)`

Rewrote readme to include the `direction` argument. The changed example segment now runs correctly.